### PR TITLE
Add test for vtkCesium3DTilesWriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 #
 build*/
 .vs/
+# temporary!
+11_vs/

--- a/09_vtk_tutorial/.vscode/settings.json
+++ b/09_vtk_tutorial/.vscode/settings.json
@@ -5,5 +5,9 @@
         "jsoncpp",
         "Voronoi",
         "voronoy"
-    ]
+    ],
+    "files.associations": {
+        "filesystem": "cpp",
+        "chrono": "cpp"
+    }
 }

--- a/09_vtk_tutorial/CMakeLists.txt
+++ b/09_vtk_tutorial/CMakeLists.txt
@@ -14,6 +14,10 @@ if(BUILD_TESTING)
     list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 project(09_vtk_tutorial)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -43,6 +47,8 @@ find_package(VTK COMPONENTS
     fmt
     InteractionStyle
     InteractionWidgets
+    IOCesium3DTiles
+    IOGeometry
     IOImport
     RenderingAnnotation
     RenderingContextOpenGL2
@@ -112,6 +118,7 @@ if(BUILD_TESTING)
     add_executable(test_09
         test_boost.cpp
         test_vtk.cpp
+        README.md
     )
     target_link_libraries(
         test_09

--- a/09_vtk_tutorial/test_vtk.cpp
+++ b/09_vtk_tutorial/test_vtk.cpp
@@ -6,15 +6,65 @@
 #include <iostream>
 #include <string>
 
+#include <filesystem>
+namespace fs = std::filesystem;
+
 #include "vtkNamedColors.h"
 #include "vtkSmartPointer.h"
 #include "vtk_jsoncpp.h"
 
 #include "../common/DebuggingConsole.h"
 
-/// @brief 
+// "test" console output
+#if _DEBUG
+#define CONSOLE_T(x)                                                           \
+    do {                                                                       \
+        std::cout << test_case_name() << "." << test_name() << ": " << x       \
+                  << '\n';                                                     \
+    } while (0)
+#else
+#define CONSOLE_T(x)
+#endif
+
+#define CONSOLE_TE(x) CONSOLE_T(#x << " : " << (x))
+
+/// @brief
 class VTK_F : public testing::Test {
 public:
+    const char *test_case_name() const {
+        // https://google.github.io/googletest/advanced.html#getting-the-current-tests-name
+        // Gets information about the currently running test.
+        // Do NOT delete the returned object - it's managed by the UnitTest
+        // class.
+        const testing::TestInfo *const test_info =
+            testing::UnitTest::GetInstance()->current_test_info();
+
+        return test_info->test_case_name();
+    }
+
+    const char *test_name() const {
+        // https://google.github.io/googletest/advanced.html#getting-the-current-tests-name
+        // Gets information about the currently running test.
+        // Do NOT delete the returned object - it's managed by the UnitTest
+        // class.
+        const testing::TestInfo *const test_info =
+            testing::UnitTest::GetInstance()->current_test_info();
+
+        return test_info->name();
+    }
+
+    fs::path create_workspace() {
+        auto ws = fs::path("out") / test_case_name() / test_name();
+        if (fs::is_directory(ws))
+            fs::remove_all(ws);
+        std::error_code err;
+        fs::create_directories(ws, err);
+
+        CONSOLE("ws = " << fs::absolute(ws).string());
+
+        return ws;
+    }
+
     //------------------------------------------------------------------------------
     std::vector<std::string> ParseColorNames(const std::string &colorNames) {
         // The delimiter for a color.
@@ -36,9 +86,9 @@ public:
     }
 };
 
-/// @brief 
-/// @param  
-/// @param  
+/// @brief
+/// @param
+/// @param
 TEST_F(VTK_F, vtkNamedColors_GetColorNames) {
     vtkSmartPointer<vtkNamedColors> sot =
         vtkSmartPointer<vtkNamedColors>::New();
@@ -56,8 +106,8 @@ TEST_F(VTK_F, vtkNamedColors_GetColorNames) {
     }
 }
 
-/// @brief 
-/// @param  
+/// @brief
+/// @param
 /// @param
 TEST_F(VTK_F, json_parse) {
     Json::CharReaderBuilder sot_builder;
@@ -93,4 +143,180 @@ TEST_F(VTK_F, json_parse) {
         EXPECT_TRUE(actual_b.isString());
         EXPECT_EQ(std::string("hello"), actual_b.asString());
     }
+}
+
+#include <vtkAppendPolyData.h>
+#include <vtkCesium3DTilesWriter.h>
+#include <vtkFieldData.h>
+#include <vtkLogger.h>
+#include <vtkMultiBlockDataSet.h>
+#include <vtkNew.h>
+#include <vtkOBJReader.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
+
+//------------------------------------------------------------------------------
+std::array<double, 3> ReadOBJOffset(const char *comment) {
+    std::array<double, 3> translation = {0, 0, 0};
+    if (comment) {
+        std::istringstream istr(comment);
+        std::array<std::string, 3> axesNames = {"x", "y", "z"};
+        for (int i = 0; i < 3; ++i) {
+            std::string axis;
+            std::string s;
+            istr >> axis >> s >> translation[i];
+            if (istr.fail()) {
+                vtkLog(WARNING,
+                       "Cannot read axis " << axesNames[i] << " from comment.");
+            }
+            if (axis != axesNames[i]) {
+                vtkLog(WARNING,
+                       "Invalid axis " << axesNames[i] << ": " << axis);
+            }
+        }
+    } else {
+        vtkLog(WARNING, "nullptr comment.");
+    }
+    return translation;
+}
+
+vtkSmartPointer<vtkPolyData> ReadOBJMesh(int numberOfBuildings,
+                                         int vtkNotUsed(lod),
+                                         const std::vector<std::string> &files,
+                                         std::array<double, 3> &fileOffset) {
+    vtkNew<vtkAppendPolyData> append;
+    for (size_t i = 0;
+         i < files.size() && i < static_cast<size_t>(numberOfBuildings); ++i) {
+        vtkNew<vtkOBJReader> reader;
+        reader->SetFileName(files[i].c_str());
+        reader->Update();
+        if (i == 0) {
+            fileOffset = ReadOBJOffset(reader->GetComment());
+        }
+        auto polyData = reader->GetOutput();
+        append->AddInputDataObject(polyData);
+    }
+    append->Update();
+    return append->GetOutput();
+}
+
+//------------------------------------------------------------------------------
+void SetField(vtkDataObject *obj, const char *name, const char *value) {
+    vtkFieldData *fd = obj->GetFieldData();
+    if (!fd) {
+        vtkNew<vtkFieldData> newfd;
+        obj->SetFieldData(newfd);
+        fd = newfd;
+    }
+    vtkNew<vtkStringArray> sa;
+    sa->SetNumberOfTuples(1);
+    sa->SetValue(0, value);
+    sa->SetName(name);
+    fd->AddArray(sa);
+}
+
+//------------------------------------------------------------------------------
+std::string GetOBJTextureFileName(const std::string &file) {
+    std::string fileNoExt = fs::path(file).stem().string();
+    std::string textureFileName = fileNoExt + ".png";
+    return fs::is_regular_file(textureFileName) ? textureFileName
+                                                : std::string();
+}
+
+vtkSmartPointer<vtkMultiBlockDataSet>
+ReadOBJBuildings(int numberOfBuildings, int vtkNotUsed(lod),
+                 std::vector<std::string> const &files,
+                 std::array<double, 3> &fileOffset) {
+    auto root = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+    for (size_t i = 0;
+         i < files.size() && i < static_cast<size_t>(numberOfBuildings); ++i) {
+        vtkNew<vtkOBJReader> reader;
+        reader->SetFileName(files[i].c_str());
+        reader->Update();
+        if (i == 0) {
+            fileOffset = ReadOBJOffset(reader->GetComment());
+        }
+        auto polyData = reader->GetOutput();
+        std::string textureFileName = GetOBJTextureFileName(files[i]);
+        if (!textureFileName.empty()) {
+            SetField(polyData, "texture_uri", textureFileName.c_str());
+        }
+        auto building = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+        building->SetBlock(0, polyData);
+        root->SetBlock(root->GetNumberOfBlocks(), building);
+    }
+    return root;
+}
+
+TEST_F(VTK_F, vtk_t00) {
+    auto ws = create_workspace();
+
+    using namespace vtksys;
+
+    std::array<double, 3> fileOffset;
+    vtkSmartPointer<vtkMultiBlockDataSet> actual = ReadOBJBuildings(
+        1, 42, {R"(V:\Asset Importer Test Models\models\OBJ\box.obj)"},
+        fileOffset);
+    ASSERT_TRUE(actual);
+    CONSOLE_TE(actual->GetNumberOfBlocks());
+}
+
+/// @brief
+/// @see
+/// https://gitlab.kitware.com/vtk/vtk/-/blob/v9.3.0/IO/Cesium3DTiles/Testing/Cxx/TestCesium3DTilesWriter.cxx
+/// @param
+/// @param
+TEST_F(VTK_F, Cesium3DTilesWriter) {
+    auto ws = create_workspace();
+
+    using namespace vtksys;
+
+    std::string textureBaseDirectory = ws.string(); // TODO: set
+    std::array<double, 3> fileOffset;
+
+    const std::vector<std::string> input;
+    int inputType = vtkCesium3DTilesWriter::Mesh;
+    bool addColor{};
+    std::string output = ws.string();
+    bool contentGLTF = true;
+    int numberOfBuildings{};
+    int buildingsPerTile{};
+    int lod{};
+    std::vector<double> inputOffset;
+    bool saveTiles = true;
+    bool saveTextures = true;
+    std::string crs;
+    int utmZone = 19; // Maine
+    char utmHemisphere = 'N';
+
+    vtkSmartPointer<vtkMultiBlockDataSet> mbData = ReadOBJBuildings(
+        1, 42, {R"(V:\Asset Importer Test Models\models\OBJ\box.obj)"},
+        fileOffset);
+    ASSERT_TRUE(mbData);
+    EXPECT_EQ(1, mbData->GetNumberOfBlocks());
+
+    vtkNew<vtkCesium3DTilesWriter> writer;
+
+    writer->SetInputDataObject(mbData);
+
+    writer->SetContentGLTF(contentGLTF);
+    writer->ContentGLTFSaveGLBOff();
+    writer->SetInputType(inputType);
+    writer->SetDirectoryName(output.c_str());
+    writer->SetTextureBaseDirectory(textureBaseDirectory.c_str());
+    writer->SetOffset(fileOffset.data());
+    writer->SetSaveTextures(saveTextures);
+    writer->SetNumberOfFeaturesPerTile(buildingsPerTile);
+    writer->SetSaveTiles(saveTiles);
+    if (crs.empty()) {
+        std::ostringstream ostr;
+        ostr << "+proj=utm +zone=" << utmZone
+             << (utmHemisphere == 'S' ? "+south" : "");
+        crs = ostr.str();
+    }
+    writer->SetCRS(crs.c_str());
+    int rc = writer->Write();
+
+    CONSOLE_T("rc = " << rc);
 }


### PR DESCRIPTION
This PR adds a comprehensive test for the VTK Cesium3DTiles writer functionality. The test includes reading OBJ files, setting up field data, and testing the writer with various configuration options.

- Adds test infrastructure with workspace creation and debugging utilities
- Implements OBJ file reading functionality with texture support
- Creates a test case for vtkCesium3DTilesWriter with proper setup and configuration